### PR TITLE
removed flawed cast_range field in struct _StSHAREDMEMORY

### DIFF
--- a/Injection/Core/shared.h
+++ b/Injection/Core/shared.h
@@ -15,7 +15,6 @@ typedef struct _StSHAREDMEMORY
 
 	BOOL  write_packetlog;
 	BOOL  freemouse;
-	int   cast_range;
 	int   ground_zbias;
 	int   alphalevel;
 	BOOL  m2e;


### PR DESCRIPTION
It was introduced in https://github.com/X-EcutiOnner/SimpleROHook/commit/dd1b265 causing an offset of the struct data 